### PR TITLE
Permit to change the URL used to connect to TeamSupport JSON API, via config.URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Python TeamSupport Client
 
 |Build Status| |Latest Version|
 
-Python library for interfacing with the TeamSupport XML API, using `demands <https://github.com/yola/demands>`__.
+Python library for interfacing with the TeamSupport JSON API, using `demands <https://github.com/yola/demands>`__.
 
 Free software: MIT license
 

--- a/teamsupport/config.py
+++ b/teamsupport/config.py
@@ -1,5 +1,6 @@
 ORG_ID = None
 AUTH_KEY = None
+#URL = https://app.teamsupport.com/api/json/
 
 DEFAULT_TICKET_STATUS = 'New'
 DEFAULT_TICKET_TYPE = 'Support'

--- a/teamsupport/services.py
+++ b/teamsupport/services.py
@@ -30,10 +30,11 @@ class TeamSupportService(HTTPServiceClient):
             tickets = res['Tickets']
             if not type(tickets) == list: # an array is not returned by TeamSupport if one only ticket in response
                 yield tickets
-                raise StopIteration
+                return
             for ticket in tickets:
                 yield ticket
-            if res.get('NextPage') is None: raise StopIteration
+            if res.get('NextPage') is None:
+                return
             page += 1
 
     def search_contacts(self, **query_params):

--- a/teamsupport/services.py
+++ b/teamsupport/services.py
@@ -15,7 +15,7 @@ class TeamSupportService(HTTPServiceClient):
                 ' To run integration tests edit config.py manually')
 
         super(TeamSupportService, self).__init__(
-            url='https://app.teamsupport.com/api/json/',
+            url=config.URL if hasattr(config, 'URL') else 'https://app.teamsupport.com/api/json/',
             auth=(config.ORG_ID, config.AUTH_KEY), **kwargs)
 
     def search_tickets(self, **query_params):

--- a/teamsupport/services.py
+++ b/teamsupport/services.py
@@ -81,6 +81,23 @@ class TeamSupportService(HTTPServiceClient):
             'tickets/{0}/Actions/{1}'.format(
                 ticket_id, action_id)).json()['Action']
 
+    def get_ticket_action_attachments(self, ticket_id, action_id, **query_params):
+        return self.get(
+            'tickets/{0}/Actions/{1}'.format(ticket_id, action_id),
+            params=query_params).json()['Attachments']
+
+    def get_ticket_action_attachment_file(self, ticket_id, action_id, attachment_id, **query_params):
+        return self.get(
+            'tickets/{0}/Actions/{1}/Attachments/{2}'.format(ticket_id, action_id, attachment_id),
+            params=query_params)
+
+    def set_ticket_jira_key(self, ticket_id, jira_key):
+        # https://support.teamsupport.com/knowledgeBase/20136103
+        return self.put(
+            'tickets/{0}'.format(ticket_id),
+            json={'Ticket': [{'JiraKey': jira_key}]},
+        ).json()['Ticket']
+
     def get_ticket_statuses(self):
         return self.get(
             'properties/ticketstatuses/').json()['TicketStatuses']

--- a/teamsupport/services.py
+++ b/teamsupport/services.py
@@ -83,7 +83,7 @@ class TeamSupportService(HTTPServiceClient):
 
     def get_ticket_action_attachments(self, ticket_id, action_id, **query_params):
         return self.get(
-            'tickets/{0}/Actions/{1}'.format(ticket_id, action_id),
+            'tickets/{0}/Actions/{1}/Attachments'.format(ticket_id, action_id),
             params=query_params).json()['Attachments']
 
     def get_ticket_action_attachment_file(self, ticket_id, action_id, attachment_id, **query_params):


### PR DESCRIPTION
Hello, teamsupport teams provided us an URL different from https://app.teamsupport.com/api/json/ hardcoded in teamsupport-python.

So, we add to do this change. It does not change the signature of init() method, so the way we are using it now is:
```
import teamsupport
teamsupport.config.URL="<TS JSON API url>"
teamsupport.init(orgid, api_key)
```
